### PR TITLE
Add pricing calculator page

### DIFF
--- a/build-site.js
+++ b/build-site.js
@@ -355,6 +355,26 @@ const pages = [
             navTargetPage: '/',
             hideHeaderFooter: true // Clean flow without header/footer
         }
+    },
+    {
+        name: 'pricing-calculator',
+        template: 'pages/pricing-calculator.ejs',
+        output: 'pricing-calculator.html',
+        data: {
+            title: 'Build Your Potions Plan | Potions',
+            description: 'Configure your Potions newsletter plan and add-ons. See live pricing and check out in one step.',
+            keywords: 'Potions pricing, newsletter pricing, B2B newsletter plan',
+            author: 'Potions',
+            baseUrl: '',
+            styleSheet: 'style.css',
+            additionalCSS: ['onboarding.css', 'css/pricing-calculator.css'],
+            showBlogLink: false,
+            tracking: true,
+            scripts: [],
+            canonicalUrl: 'https://withpotions.com/pricing-calculator.html',
+            navTargetPage: '/',
+            hideHeaderFooter: true
+        }
     }
 ];
 

--- a/css/pricing-calculator.css
+++ b/css/pricing-calculator.css
@@ -1,0 +1,724 @@
+/* Potions Pricing Calculator Styles
+ * Extends onboarding.css — assumes onboarding.css is already loaded.
+ * Uses the same .onboarding-wrapper / .onboarding-container / .onboarding-step
+ * shell classes for visual consistency.
+ */
+
+/* ==================== */
+/* Dev Mode Banner      */
+/* ==================== */
+
+.dev-banner {
+  display: none;
+  background-color: #ff4444;
+  color: white;
+  text-align: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 9999;
+  box-sizing: border-box;
+}
+
+body.dev-mode-active {
+  padding-top: 2rem;
+}
+
+/* ==================== */
+/* Pricing Step Widths  */
+/* ==================== */
+
+/* Step 1 has more content — allow a wider container */
+#pricing-step-1 {
+  max-width: 860px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ==================== */
+/* Billing Toggle       */
+/* ==================== */
+
+.billing-toggle-section {
+  margin-bottom: 2rem;
+}
+
+.billing-toggle-label {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #333;
+  margin-bottom: 0.75rem;
+  display: block;
+}
+
+.billing-toggle {
+  display: inline-flex;
+  background-color: #f0f0f0;
+  border-radius: 8px;
+  padding: 4px;
+  gap: 4px;
+}
+
+.billing-btn {
+  padding: 0.5rem 1.25rem;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: 'Prosa-Light', Helvetica, Arial, sans-serif;
+  color: #666;
+  background-color: transparent;
+  transition: all 0.2s ease;
+}
+
+.billing-btn:hover {
+  color: #333;
+}
+
+.billing-btn.active {
+  background-color: white;
+  color: #5D5DED;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+}
+
+/* ==================== */
+/* List Size Selector   */
+/* ==================== */
+
+.list-size-section {
+  margin-bottom: 2rem;
+}
+
+.list-size-label {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #333;
+  margin-bottom: 0.75rem;
+  display: block;
+}
+
+.list-size-select {
+  padding: 0.75rem 1rem;
+  border: 2px solid #333;
+  border-radius: 8px;
+  font-family: 'Prosa-Light', Helvetica, Arial, sans-serif;
+  font-size: 1rem;
+  color: #333;
+  background-color: white;
+  cursor: pointer;
+  min-width: 260px;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  padding-right: 2.5rem;
+}
+
+.list-size-select:focus {
+  outline: none;
+  border-color: #5D5DED;
+}
+
+/* ==================== */
+/* Core Price Row       */
+/* ==================== */
+
+.core-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border: 3px solid #5D5DED;
+  border-radius: 10px;
+  background-color: #f8f7ff;
+  margin-bottom: 1.5rem;
+}
+
+.core-row-info {
+  flex: 1;
+}
+
+.core-row-name {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: #333;
+  margin-bottom: 0.25rem;
+}
+
+.core-row-sub {
+  font-size: 0.9rem;
+  color: #666;
+}
+
+.core-row-price {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.core-price-amount {
+  display: block;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #5D5DED;
+}
+
+.core-price-period {
+  display: block;
+  font-size: 0.85rem;
+  color: #666;
+  margin-top: 0.2rem;
+}
+
+/* ==================== */
+/* Add-ons Section      */
+/* ==================== */
+
+.addons-section-label {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #333;
+  margin-bottom: 1rem;
+  display: block;
+}
+
+.addons-table {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.addon-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  padding: 1.25rem 1.5rem;
+  border: 3px solid #333;
+  border-radius: 10px;
+  background-color: white;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.addon-row:hover {
+  border-color: #5D5DED;
+}
+
+.addon-row.selected {
+  border-color: #5D5DED;
+  background-color: #f8f7ff;
+}
+
+.addon-checkbox-col {
+  padding-top: 2px;
+  flex-shrink: 0;
+}
+
+.addon-checkbox {
+  width: 22px;
+  height: 22px;
+  accent-color: #5D5DED;
+  cursor: pointer;
+}
+
+.addon-info-col {
+  flex: 1;
+  min-width: 0;
+}
+
+.addon-name {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: #333;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+  flex-wrap: wrap;
+}
+
+.sale-badge {
+  display: inline-block;
+  background-color: #22c55e;
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+}
+
+.addon-description {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.addon-description li {
+  font-size: 0.9rem;
+  color: #666;
+  line-height: 1.5;
+  padding: 0.2rem 0;
+  position: relative;
+  padding-left: 1.25rem;
+}
+
+.addon-description li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  color: #5D5DED;
+  font-weight: bold;
+}
+
+.addon-price-col {
+  text-align: right;
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding-top: 2px;
+}
+
+.original-price {
+  display: block;
+  text-decoration: line-through;
+  color: #999;
+  font-size: 0.9rem;
+}
+
+.sale-price {
+  display: block;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #5D5DED;
+}
+
+.addon-price-amount {
+  display: block;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #333;
+}
+
+.addon-price-period {
+  display: block;
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 0.15rem;
+}
+
+.addon-price-onetime {
+  display: block;
+  font-size: 0.75rem;
+  color: #888;
+  margin-top: 0.15rem;
+  font-style: italic;
+}
+
+/* ==================== */
+/* Price Summary Bar    */
+/* ==================== */
+
+.price-summary-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem;
+  background-color: #333;
+  color: white;
+  border-radius: 10px;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.price-summary-label {
+  font-size: 1rem;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.price-summary-total {
+  text-align: right;
+}
+
+.price-summary-recurring {
+  font-size: 1.6rem;
+  font-weight: 700;
+  display: block;
+}
+
+.price-summary-period {
+  font-size: 0.85rem;
+  opacity: 0.7;
+  display: block;
+}
+
+.price-summary-onetime {
+  font-size: 0.9rem;
+  opacity: 0.8;
+  display: block;
+  margin-top: 0.25rem;
+}
+
+/* ==================== */
+/* Order Summary (Step 2) */
+/* ==================== */
+
+.order-summary-title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #333;
+  margin-bottom: 1.5rem;
+}
+
+.order-summary-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem 0;
+  border: 2px solid #e0e0e0;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.order-summary-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #e0e0e0;
+  gap: 1rem;
+}
+
+.order-summary-item:last-child {
+  border-bottom: none;
+}
+
+.order-item-name {
+  font-weight: 600;
+  color: #333;
+  font-size: 1rem;
+}
+
+.order-item-sub {
+  font-size: 0.85rem;
+  color: #888;
+  margin-top: 0.2rem;
+}
+
+.order-item-price {
+  font-weight: 700;
+  color: #333;
+  white-space: nowrap;
+  font-size: 1rem;
+}
+
+.order-summary-divider {
+  border: none;
+  border-top: 2px solid #333;
+  margin: 0 0 1rem 0;
+}
+
+.order-summary-total-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.5rem;
+}
+
+.order-summary-total-label {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: #333;
+}
+
+.order-summary-total-amount {
+  font-weight: 700;
+  font-size: 1.4rem;
+  color: #5D5DED;
+}
+
+.order-summary-onetime-row {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+  color: #666;
+}
+
+.btn-pay-now {
+  display: block;
+  width: 100%;
+  padding: 1.25rem 2rem;
+  background-color: #5D5DED;
+  border: 2px solid #5D5DED;
+  border-radius: 8px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: white;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-family: 'Prosa-Light', Helvetica, Arial, sans-serif;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.btn-pay-now:hover:not(:disabled) {
+  background-color: #4848d8;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(93, 93, 237, 0.3);
+}
+
+.btn-pay-now:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-pay-now.loading {
+  opacity: 0.8;
+  cursor: not-allowed;
+}
+
+.pay-security-note {
+  text-align: center;
+  font-size: 0.875rem;
+  color: #888;
+}
+
+.dev-skip-note {
+  text-align: center;
+  font-size: 0.8rem;
+  color: #ff4444;
+  font-weight: 600;
+  margin-top: 0.5rem;
+}
+
+/* ==================== */
+/* Email Capture (Step 3) */
+/* ==================== */
+
+.email-capture-form {
+  margin-bottom: 2rem;
+}
+
+.pricing-email-input {
+  width: 100%;
+  padding: 1rem 1.25rem;
+  border: 2px solid #333;
+  border-radius: 8px;
+  font-family: 'Prosa-Light', Helvetica, Arial, sans-serif;
+  font-size: 1.1rem;
+  transition: border-color 0.3s ease;
+  margin-bottom: 0.5rem;
+  box-sizing: border-box;
+}
+
+.pricing-email-input:focus {
+  outline: none;
+  border-color: #5D5DED;
+}
+
+.email-privacy-note {
+  font-size: 0.875rem;
+  color: #888;
+  margin-bottom: 1.5rem;
+}
+
+.btn-finish-setup {
+  display: block;
+  width: 100%;
+  padding: 1.25rem 2rem;
+  background-color: #5D5DED;
+  border: 2px solid #5D5DED;
+  border-radius: 8px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: white;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-family: 'Prosa-Light', Helvetica, Arial, sans-serif;
+}
+
+.btn-finish-setup:hover:not(:disabled) {
+  background-color: #4848d8;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(93, 93, 237, 0.3);
+}
+
+.btn-finish-setup:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.email-submit-error {
+  color: #ff4444;
+  font-size: 0.9rem;
+  margin-top: 0.75rem;
+  display: none;
+}
+
+/* ==================== */
+/* Welcome Step (Step 4) */
+/* ==================== */
+
+.welcome-page {
+  text-align: center;
+}
+
+.inbox-instruction {
+  background-color: #f9f9f9;
+  border: 2px solid #e0e0e0;
+  border-radius: 10px;
+  padding: 1.5rem;
+  margin: 2rem 0;
+  text-align: left;
+}
+
+.inbox-instruction h3 {
+  font-size: 1.1rem;
+  color: #333;
+  margin-bottom: 0.75rem;
+}
+
+.inbox-instruction p {
+  color: #666;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.inbox-instruction strong {
+  color: #333;
+}
+
+/* ==================== */
+/* Mobile Responsive    */
+/* ==================== */
+
+@media (max-width: 768px) {
+  .core-row {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .core-row-price {
+    text-align: left;
+  }
+
+  .addon-row {
+    flex-wrap: wrap;
+  }
+
+  .addon-price-col {
+    text-align: left;
+    width: 100%;
+    padding-top: 0;
+    padding-left: calc(22px + 1.25rem); /* align with info col */
+  }
+
+  .price-summary-bar {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .price-summary-total {
+    text-align: center;
+  }
+
+  .billing-toggle {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .list-size-select {
+    width: 100%;
+    min-width: unset;
+  }
+
+  .order-summary-item {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .addon-row {
+    padding: 1rem;
+  }
+
+  .billing-btn {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+  }
+}
+
+/* ─────────────────────────────────────────────
+   Two-payment section layout (Step 2)
+   ───────────────────────────────────────────── */
+.payment-section {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.payment-section-onetime {
+  background: #fafafa;
+}
+
+.payment-section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.payment-section-number {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #5D5DED;
+  background: #efefff;
+  padding: 2px 8px;
+  border-radius: 100px;
+  white-space: nowrap;
+}
+
+.payment-section-type {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #111;
+}
+
+.payment-section-note {
+  font-size: 0.8rem;
+  color: #6b7280;
+  margin: 0.5rem 0 0;
+}
+
+/* Locked pay button (one-time section, before payment 1 completes) */
+.btn-pay-locked {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+
+/* Step 2b: Payment 1 confirmed banner */
+.payment-confirmed-banner {
+  background: #ecfdf5;
+  color: #065f46;
+  border: 1px solid #a7f3d0;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 1.5rem;
+}

--- a/js/pricing/app.js
+++ b/js/pricing/app.js
@@ -1,0 +1,753 @@
+/* Potions Pricing Calculator — App
+ *
+ * URL params:
+ *   ?dev=true                    — skip Stripe, jump straight to step 3 on "Pay Now"
+ *   ?billing=quarterly           — monthly | quarterly | annual
+ *   ?list_size=starter           — must match a tier id in config.js
+ *   ?addons=linkedin,performance — pre-select add-ons (comma-separated ids)
+ *   ?disabled_addons=performance — hide add-ons entirely (comma-separated ids)
+ *   ?step=3&success=true         — Stripe return URL lands directly on this step
+ */
+
+(function () {
+  'use strict';
+
+  // ─────────────────────────────────────────────
+  // State
+  // ─────────────────────────────────────────────
+  const state = {
+    step: 1,
+    billing: 'quarterly',
+    listSize: 'starter',
+    selectedAddons: new Set(),
+    disabledAddons: new Set(),
+    devMode: false,
+  };
+
+  // ─────────────────────────────────────────────
+  // URL parameter parsing
+  // ─────────────────────────────────────────────
+  function parseUrlParams() {
+    const params = new URLSearchParams(window.location.search);
+
+    if (params.get('dev') === 'true') {
+      state.devMode = true;
+    }
+
+    const billing = params.get('billing');
+    if (billing && ['monthly', 'quarterly', 'annual'].includes(billing)) {
+      state.billing = billing;
+    }
+
+    const listSize = params.get('list_size');
+    if (listSize && PRICING_CONFIG.listSizeTiers.some(t => t.id === listSize)) {
+      state.listSize = listSize;
+    }
+
+    const addons = params.get('addons');
+    if (addons) {
+      addons.split(',').forEach(id => {
+        const trimmed = id.trim();
+        if (trimmed) state.selectedAddons.add(trimmed);
+      });
+    }
+
+    const disabledAddons = params.get('disabled_addons');
+    if (disabledAddons) {
+      disabledAddons.split(',').forEach(id => {
+        const trimmed = id.trim();
+        if (trimmed) state.disabledAddons.add(trimmed);
+      });
+    }
+
+    // Payment Link success return
+    const success = params.get('success') === 'true';
+    const onetimeDone = params.get('onetime_done') === 'true';
+
+    if (success) {
+      try {
+        const saved = JSON.parse(localStorage.getItem('potions_pending_checkout') || 'null');
+        if (saved && (Date.now() - saved.ts) < 86400000) {
+          state.billing  = saved.billing  || state.billing;
+          state.listSize = saved.listSize || state.listSize;
+          (saved.selectedAddons || []).forEach(id => state.selectedAddons.add(id));
+
+          if (saved.hasPendingOneTime && !onetimeDone) {
+            state.step = 'onetime';
+          } else {
+            localStorage.removeItem('potions_pending_checkout');
+            state.step = 3;
+          }
+        } else {
+          state.step = 3;
+        }
+      } catch (e) {
+        state.step = 3;
+      }
+    } else {
+      const step = parseInt(params.get('step'), 10);
+      if (step >= 1 && step <= 4) state.step = step;
+    }
+  }
+
+  // ─────────────────────────────────────────────
+  // Price helpers
+  // ─────────────────────────────────────────────
+  const PERIOD_MULTIPLIER = { monthly: 1, quarterly: 3, annual: 12 };
+  const PERIOD_LABEL       = { monthly: '/mo', quarterly: '/quarter', annual: '/year' };
+  const PERIOD_NAME        = { monthly: 'monthly', quarterly: 'quarterly', annual: 'annually' };
+
+  function getCurrentTier() {
+    return (
+      PRICING_CONFIG.listSizeTiers.find(t => t.id === state.listSize) ||
+      PRICING_CONFIG.listSizeTiers[0]
+    );
+  }
+
+  function coreRatePerMonth() {
+    return getCurrentTier().rates[state.billing] || getCurrentTier().rates.quarterly;
+  }
+
+  function addonRatePerMonth(addon) {
+    if (addon.billingType === 'one_time') return 0;
+    if (addon.id === 'linkedin') return addon.salePricePerMonth;
+    if (addon.id === 'content-interviews') return addon.pricePerMonth;
+    return 0;
+  }
+
+  function formatCurrency(n) {
+    return '$' + n.toLocaleString('en-US');
+  }
+
+  // Returns { recurring: Number (per month), oneTime: Number }
+  function calcTotals() {
+    let recurringPerMonth = coreRatePerMonth();
+    let oneTime = 0;
+
+    state.selectedAddons.forEach(addonId => {
+      const addon = PRICING_CONFIG.addons.find(a => a.id === addonId);
+      if (!addon || !addon.enabled || state.disabledAddons.has(addonId)) return;
+
+      if (addon.billingType === 'recurring') {
+        recurringPerMonth += addonRatePerMonth(addon);
+      } else {
+        oneTime += addon.flatPrice;
+      }
+    });
+
+    return { recurringPerMonth, oneTime };
+  }
+
+  // Returns the correct recurring Payment Link URL for the current billing + addon selection
+  function getRecurringPaymentLink() {
+    const parts = ['core'];
+    if (state.selectedAddons.has('linkedin')) parts.push('linkedin');
+    if (state.selectedAddons.has('content-interviews')) parts.push('content-interviews');
+    const key = parts.join('+');
+    const links = PRICING_CONFIG.paymentLinks.recurring[state.billing];
+    return (links && links[key]) || null;
+  }
+
+  // Returns enabled one-time add-ons the user has selected
+  function getSelectedOneTimeAddons() {
+    return PRICING_CONFIG.addons.filter(a =>
+      a.billingType === 'one_time' &&
+      a.enabled &&
+      state.selectedAddons.has(a.id) &&
+      !state.disabledAddons.has(a.id)
+    );
+  }
+
+  // ─────────────────────────────────────────────
+  // Step navigation
+  // ─────────────────────────────────────────────
+  function showStep(n) {
+    if (n === 'onetime') { showStep2b(); return; }
+
+    document.querySelectorAll('.pricing-step').forEach(el => {
+      el.style.display = 'none';
+    });
+
+    const el = document.getElementById('pricing-step-' + n);
+    if (!el) return;
+    el.style.display = 'block';
+
+    // Progress bar
+    const pct = Math.round((n / 4) * 100);
+    const fill = document.getElementById('pricing-progress-fill');
+    const text = document.getElementById('pricing-progress-text');
+    if (fill) fill.style.width = pct + '%';
+    if (text) text.textContent = 'Step ' + n + ' of 4';
+
+    state.step = n;
+
+    if (n === 1) renderStep1();
+    if (n === 2) renderStep2();
+    if (n === 3) setupStep3();
+    if (n === 4) {
+      try { localStorage.removeItem('potions_pending_checkout'); } catch(e) {}
+      renderStep4();
+    }
+  }
+
+  // ─────────────────────────────────────────────
+  // Step 1 — Plan configuration
+  // ─────────────────────────────────────────────
+  function renderStep1() {
+    renderBillingToggle();
+    renderListSizeSelect();
+    renderCoreRow();
+    renderAddonsTable();
+    renderPriceSummary();
+  }
+
+  function renderBillingToggle() {
+    const container = document.getElementById('billing-toggle');
+    if (!container) return;
+
+    container.querySelectorAll('.billing-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.billing === state.billing);
+    });
+  }
+
+  function renderListSizeSelect() {
+    const select = document.getElementById('list-size-select');
+    if (!select) return;
+
+    // Populate options if not already done
+    if (!select.dataset.populated) {
+      select.innerHTML = PRICING_CONFIG.listSizeTiers.map(tier =>
+        `<option value="${tier.id}">${tier.label}</option>`
+      ).join('');
+      select.dataset.populated = '1';
+    }
+
+    select.value = state.listSize;
+  }
+
+  function renderCoreRow() {
+    const el = document.getElementById('core-price-amount');
+    const period = document.getElementById('core-price-period');
+    if (!el) return;
+
+    const rate = coreRatePerMonth();
+    el.textContent = formatCurrency(rate) + '/mo';
+    if (period) {
+      period.textContent = 'billed ' + PERIOD_NAME[state.billing];
+    }
+  }
+
+  function renderAddonsTable() {
+    const container = document.getElementById('addons-table');
+    if (!container) return;
+
+    const visibleAddons = PRICING_CONFIG.addons.filter(
+      a => a.enabled && !state.disabledAddons.has(a.id)
+    );
+
+    if (visibleAddons.length === 0) {
+      container.innerHTML = '';
+      return;
+    }
+
+    container.innerHTML = visibleAddons.map(addon => {
+      const isSelected = state.selectedAddons.has(addon.id);
+      return `
+        <div class="addon-row${isSelected ? ' selected' : ''}" data-addon-id="${addon.id}">
+          <div class="addon-checkbox-col">
+            <input
+              type="checkbox"
+              class="addon-checkbox"
+              id="addon-cb-${addon.id}"
+              data-addon-id="${addon.id}"
+              ${isSelected ? 'checked' : ''}
+            />
+          </div>
+          <div class="addon-info-col">
+            <label for="addon-cb-${addon.id}" class="addon-name">
+              ${escapeHtml(addon.name)}
+              ${addon.saleLabel ? `<span class="sale-badge">${escapeHtml(addon.saleLabel)}</span>` : ''}
+            </label>
+            <ul class="addon-description">
+              ${(addon.description || []).map(b => `<li>${escapeHtml(b)}</li>`).join('')}
+            </ul>
+          </div>
+          <div class="addon-price-col">
+            ${renderAddonPrice(addon)}
+          </div>
+        </div>
+      `;
+    }).join('');
+
+    // Attach events
+    container.querySelectorAll('.addon-checkbox').forEach(cb => {
+      cb.addEventListener('change', onAddonChange);
+    });
+
+    // Clicking the row also toggles
+    container.querySelectorAll('.addon-row').forEach(row => {
+      row.addEventListener('click', function (e) {
+        if (e.target.type === 'checkbox' || e.target.tagName === 'LABEL' || e.target.tagName === 'A') return;
+        const cb = row.querySelector('.addon-checkbox');
+        if (cb) {
+          cb.checked = !cb.checked;
+          cb.dispatchEvent(new Event('change'));
+        }
+      });
+    });
+  }
+
+  function renderAddonPrice(addon) {
+    const periodLabel = PERIOD_LABEL[state.billing];
+    const multiplier  = PERIOD_MULTIPLIER[state.billing];
+
+    if (addon.billingType === 'one_time') {
+      return `
+        <span class="addon-price-amount">${escapeHtml(addon.priceLabel)}</span>
+        <span class="addon-price-onetime">one-time</span>
+      `;
+    }
+
+    if (addon.id === 'linkedin') {
+      return `
+        <span class="original-price">${formatCurrency(addon.originalPricePerMonth)}/mo</span>
+        <span class="sale-price">${formatCurrency(addon.salePricePerMonth)}/mo</span>
+        <span class="addon-price-period">billed ${PERIOD_NAME[state.billing]}</span>
+      `;
+    }
+
+    if (addon.id === 'content-interviews') {
+      return `
+        <span class="addon-price-amount">${formatCurrency(addon.pricePerMonth)}/mo</span>
+        <span class="addon-price-period">billed ${PERIOD_NAME[state.billing]}</span>
+      `;
+    }
+
+    return `<span class="addon-price-amount">${escapeHtml(addon.priceLabel || '')}</span>`;
+  }
+
+  function renderPriceSummary() {
+    const { recurringPerMonth, oneTime } = calcTotals();
+    const periodLabel = PERIOD_LABEL[state.billing];
+
+    const recurringEl = document.getElementById('price-summary-recurring');
+    const periodEl    = document.getElementById('price-summary-period');
+    const onetimeEl   = document.getElementById('price-summary-onetime');
+
+    if (recurringEl) {
+      recurringEl.textContent = formatCurrency(recurringPerMonth) + '/mo';
+    }
+    if (periodEl) {
+      periodEl.textContent = 'billed ' + PERIOD_NAME[state.billing];
+    }
+    if (onetimeEl) {
+      if (oneTime > 0) {
+        onetimeEl.textContent = '+ ' + formatCurrency(oneTime) + ' one-time';
+        onetimeEl.style.display = 'block';
+      } else {
+        onetimeEl.style.display = 'none';
+      }
+    }
+  }
+
+  function onAddonChange(e) {
+    const addonId = e.target.dataset.addonId;
+    if (!addonId) return;
+
+    if (e.target.checked) {
+      state.selectedAddons.add(addonId);
+    } else {
+      state.selectedAddons.delete(addonId);
+    }
+
+    // Update row styling
+    const row = e.target.closest('.addon-row');
+    if (row) row.classList.toggle('selected', e.target.checked);
+
+    renderCoreRow();
+    renderAddonPrice(PRICING_CONFIG.addons.find(a => a.id === addonId) || {});
+    renderPriceSummary();
+  }
+
+  // ─────────────────────────────────────────────
+  // Step 2 — Review & Pay
+  // ─────────────────────────────────────────────
+  function renderStep2() {
+    const container = document.getElementById('order-summary');
+    if (!container) return;
+
+    const tier = getCurrentTier();
+    const rate = coreRatePerMonth();
+    const { recurringPerMonth, oneTime } = calcTotals();
+
+    const selectedAddonObjects = PRICING_CONFIG.addons.filter(
+      a => state.selectedAddons.has(a.id) && a.enabled && !state.disabledAddons.has(a.id)
+    );
+    const recurringAddonObjects = selectedAddonObjects.filter(a => a.billingType === 'recurring');
+    const oneTimeAddonObjects   = selectedAddonObjects.filter(a => a.billingType === 'one_time');
+
+    // ── Core item ──
+    const coreItem = `
+      <li class="order-summary-item">
+        <div>
+          <div class="order-item-name">Potions Newsletter — ${tier.label}</div>
+          <div class="order-item-sub">Core newsletter service</div>
+        </div>
+        <div class="order-item-price">${formatCurrency(rate)}/mo</div>
+      </li>
+    `;
+
+    function addonItemHtml(addon) {
+      let price = '';
+      if (addon.billingType === 'one_time') {
+        price = formatCurrency(addon.flatPrice) + ' one-time';
+      } else if (addon.id === 'linkedin') {
+        price = formatCurrency(addon.salePricePerMonth) + '/mo';
+      } else if (addon.id === 'content-interviews') {
+        price = formatCurrency(addon.pricePerMonth) + '/mo';
+      }
+      return `
+        <li class="order-summary-item">
+          <div><div class="order-item-name">${escapeHtml(addon.name)}</div></div>
+          <div class="order-item-price">${price}</div>
+        </li>
+      `;
+    }
+
+    let html = '';
+
+    if (oneTimeAddonObjects.length > 0) {
+      // ── Two-section layout — each section has its own pay button ──
+      const recurringItems = coreItem + recurringAddonObjects.map(addonItemHtml).join('');
+
+      const oneTimeItems = oneTimeAddonObjects.map(addonItemHtml).join('');
+
+      html = `
+        <div class="payment-section">
+          <div class="payment-section-header">
+            <span class="payment-section-number">Payment 1 of 2</span>
+            <span class="payment-section-type">Subscription</span>
+          </div>
+          <ul class="order-summary-list">${recurringItems}</ul>
+          <hr class="order-summary-divider" />
+          <div class="order-summary-total-row">
+            <span class="order-summary-total-label">Recurring total</span>
+            <span class="order-summary-total-amount">${formatCurrency(recurringPerMonth)}/mo billed ${PERIOD_NAME[state.billing]}</span>
+          </div>
+          <button class="btn-pay-now" id="btn-pay-subscription" style="margin-top:1.25rem;width:100%;">
+            Pay ${formatCurrency(recurringPerMonth)}/mo &rarr;
+          </button>
+        </div>
+        <div class="payment-section payment-section-onetime">
+          <div class="payment-section-header">
+            <span class="payment-section-number">Payment 2 of 2</span>
+            <span class="payment-section-type">One-time add-ons</span>
+          </div>
+          <ul class="order-summary-list">${oneTimeItems}</ul>
+          <hr class="order-summary-divider" />
+          <div class="order-summary-total-row">
+            <span class="order-summary-total-label">One-time total</span>
+            <span class="order-summary-total-amount">${formatCurrency(oneTime)}</span>
+          </div>
+          <button class="btn-pay-now btn-pay-locked" disabled style="margin-top:1.25rem;width:100%;">
+            Pay ${formatCurrency(oneTime)} &rarr;
+          </button>
+          <p class="payment-section-note">Available after you complete payment 1</p>
+        </div>
+      `;
+
+      // Hide the global pay-now button (we rendered one inside the section)
+      const globalBtn = document.getElementById('btn-pay-now');
+      if (globalBtn) globalBtn.style.display = 'none';
+    } else {
+      // ── Single-section layout (no one-time add-ons) ──
+      const addonItems = recurringAddonObjects.map(addonItemHtml).join('');
+      html = `
+        <p class="order-summary-title">Your Order</p>
+        <ul class="order-summary-list">
+          ${coreItem}
+          ${addonItems}
+        </ul>
+        <hr class="order-summary-divider" />
+        <div class="order-summary-total-row">
+          <span class="order-summary-total-label">Recurring total</span>
+          <span class="order-summary-total-amount">${formatCurrency(recurringPerMonth)}/mo billed ${PERIOD_NAME[state.billing]}</span>
+        </div>
+      `;
+    }
+
+    container.innerHTML = html;
+
+    if (oneTimeAddonObjects.length > 0) {
+      // Attach click handler to the inline subscription pay button
+      const subBtn = document.getElementById('btn-pay-subscription');
+      if (subBtn) subBtn.addEventListener('click', initiateCheckout);
+    } else {
+      // Restore the global pay-now button (may have been hidden by a previous render)
+      const globalBtn = document.getElementById('btn-pay-now');
+      if (globalBtn) globalBtn.style.display = '';
+    }
+
+    // Dev note on pay button
+    const devNote = document.getElementById('dev-skip-note');
+    if (devNote) devNote.style.display = state.devMode ? 'block' : 'none';
+  }
+
+  // ─────────────────────────────────────────────
+  // Step 2b — One-time add-on payment interstitial
+  // ─────────────────────────────────────────────
+  function showStep2b() {
+    document.querySelectorAll('.pricing-step').forEach(el => { el.style.display = 'none'; });
+    const el = document.getElementById('pricing-step-2b');
+    if (!el) { showStep(3); return; }
+    el.style.display = 'block';
+
+    const fill = document.getElementById('pricing-progress-fill');
+    const text = document.getElementById('pricing-progress-text');
+    if (fill) fill.style.width = '50%';
+    if (text) text.textContent = 'Almost done!';
+
+    renderStep2b();
+  }
+
+  function renderStep2b() {
+    const container = document.getElementById('onetime-payment-items');
+    if (!container) return;
+
+    const oneTimeAddons = getSelectedOneTimeAddons();
+
+    container.innerHTML = oneTimeAddons.map(function(addon) {
+      const link = PRICING_CONFIG.paymentLinks.oneTime[addon.id];
+      const isPlaceholder = !link || link.includes('PLACEHOLDER');
+      const buttonHtml = isPlaceholder
+        ? '<span class="onetime-link-unavailable">Link coming soon</span>'
+        : '<a href="' + link + '" target="_blank" rel="noopener" class="btn-pay-now onetime-pay-btn">Pay ' + escapeHtml(addon.priceLabel) + ' &rarr;</a>';
+
+      return '<div class="onetime-addon-row">' +
+        '<div>' +
+          '<div class="order-item-name">' + escapeHtml(addon.name) + '</div>' +
+          '<div class="order-item-sub">' + escapeHtml(addon.priceLabel) + ' one-time</div>' +
+        '</div>' +
+        buttonHtml +
+        '</div>';
+    }).join('');
+
+    const skipBtn = document.getElementById('btn-skip-onetime');
+    if (skipBtn) {
+      const newSkip = skipBtn.cloneNode(true);
+      skipBtn.parentNode.replaceChild(newSkip, skipBtn);
+      newSkip.addEventListener('click', function() {
+        try { localStorage.removeItem('potions_pending_checkout'); } catch(e) {}
+        showStep(3);
+      });
+    }
+  }
+
+  // ─────────────────────────────────────────────
+  // Step 3 — Email capture
+  // ─────────────────────────────────────────────
+  function setupStep3() {
+    const errEl = document.getElementById('email-submit-error');
+    if (errEl) errEl.style.display = 'none';
+
+    // Clone both elements to clear any stale event listeners from previous visits
+    const oldInput = document.getElementById('email-input');
+    const oldBtn   = document.getElementById('btn-finish-setup');
+    if (!oldInput || !oldBtn) return;
+
+    const savedValue = oldInput.value;
+
+    const input = oldInput.cloneNode(true);
+    input.value = savedValue;
+    oldInput.parentNode.replaceChild(input, oldInput);
+
+    const btn = oldBtn.cloneNode(true);
+    oldBtn.parentNode.replaceChild(btn, oldBtn);
+
+    // Sync disabled state with whatever is already in the input
+    btn.disabled = !isValidEmail(input.value.trim());
+
+    input.addEventListener('input', function () {
+      btn.disabled = !isValidEmail(input.value.trim());
+    });
+
+    btn.addEventListener('click', function () {
+      const email = input.value.trim();
+      if (!isValidEmail(email)) return;
+
+      btn.disabled = true;
+      btn.textContent = 'Setting up your account...';
+      if (errEl) errEl.style.display = 'none';
+
+      // Fire webhook non-blocking — don't let a failed webhook stop the user
+      submitEmail(email).catch(function (err) {
+        console.warn('Email webhook failed (non-blocking):', err);
+      });
+
+      showStep(4);
+    });
+  }
+
+  async function submitEmail(email) {
+    const { recurringPerMonth, oneTime } = calcTotals();
+    const payload = {
+      email,
+      billing: state.billing,
+      listSize: state.listSize,
+      selectedAddons: Array.from(state.selectedAddons),
+      recurringPerMonth,
+      oneTimeCost: oneTime,
+      timestamp: new Date().toISOString(),
+      dev: state.devMode,
+    };
+
+    await fetch(PRICING_CONFIG.webhooks.emailCapture, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  // ─────────────────────────────────────────────
+  // Step 4 — Welcome
+  // ─────────────────────────────────────────────
+  function renderStep4() {
+    // Static HTML — nothing dynamic needed
+  }
+
+  // ─────────────────────────────────────────────
+  // Payment Link checkout
+  // ─────────────────────────────────────────────
+  function initiateCheckout() {
+    const link = getRecurringPaymentLink();
+    const isPlaceholder = !link || link.includes('PLACEHOLDER');
+
+    if (state.devMode || isPlaceholder) {
+      showStep(3);
+      return;
+    }
+
+    // Persist selections so we can restore them after the Stripe redirect
+    const oneTimeAddons = getSelectedOneTimeAddons();
+    try {
+      localStorage.setItem('potions_pending_checkout', JSON.stringify({
+        billing: state.billing,
+        listSize: state.listSize,
+        selectedAddons: Array.from(state.selectedAddons),
+        hasPendingOneTime: oneTimeAddons.length > 0,
+        ts: Date.now(),
+      }));
+    } catch (e) {
+      // localStorage unavailable — continue anyway
+    }
+
+    window.open(link, '_blank');
+
+    // Advance to next step immediately — don't block on payment completion
+    if (oneTimeAddons.length > 0) {
+      showStep('onetime');
+    } else {
+      showStep(3);
+    }
+  }
+
+  // ─────────────────────────────────────────────
+  // Event listeners
+  // ─────────────────────────────────────────────
+  function attachEventListeners() {
+    // Billing toggle
+    const toggle = document.getElementById('billing-toggle');
+    if (toggle) {
+      toggle.addEventListener('click', function (e) {
+        const btn = e.target.closest('.billing-btn');
+        if (!btn) return;
+        state.billing = btn.dataset.billing;
+        renderBillingToggle();
+        renderCoreRow();
+        renderAddonsTable();
+        renderPriceSummary();
+      });
+    }
+
+    // List size select
+    const listSizeEl = document.getElementById('list-size-select');
+    if (listSizeEl) {
+      listSizeEl.addEventListener('change', function () {
+        state.listSize = this.value;
+        renderCoreRow();
+        renderPriceSummary();
+      });
+    }
+
+    // Step 1 → 2
+    const btnStep1Next = document.getElementById('btn-step1-next');
+    if (btnStep1Next) {
+      btnStep1Next.addEventListener('click', function () {
+        renderStep2();
+        showStep(2);
+      });
+    }
+
+    // Step 2 back → 1
+    const btnStep2Back = document.getElementById('btn-step2-back');
+    if (btnStep2Back) {
+      btnStep2Back.addEventListener('click', function () {
+        showStep(1);
+      });
+    }
+
+    // Pay Now
+    const btnPayNow = document.getElementById('btn-pay-now');
+    if (btnPayNow) {
+      btnPayNow.addEventListener('click', initiateCheckout);
+    }
+
+    // Step 3 back → 2
+    const btnStep3Back = document.getElementById('btn-step3-back');
+    if (btnStep3Back) {
+      btnStep3Back.addEventListener('click', function () {
+        showStep(2);
+      });
+    }
+  }
+
+  // ─────────────────────────────────────────────
+  // Utilities
+  // ─────────────────────────────────────────────
+  function isValidEmail(email) {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  }
+
+  function escapeHtml(str) {
+    if (typeof str !== 'string') return '';
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  // ─────────────────────────────────────────────
+  // Init
+  // ─────────────────────────────────────────────
+  function init() {
+    parseUrlParams();
+
+    // Dev mode banner
+    if (state.devMode) {
+      const banner = document.getElementById('dev-banner');
+      if (banner) banner.style.display = 'block';
+      document.body.classList.add('dev-mode-active');
+    }
+
+    attachEventListeners();
+    if (state.step === 'onetime') {
+      showStep2b();
+    } else {
+      showStep(state.step);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/js/pricing/config.js
+++ b/js/pricing/config.js
@@ -1,0 +1,137 @@
+/* Potions Pricing Calculator — Configuration
+ *
+ * How to update:
+ *  - Add/edit listSizeTiers to change pricing by subscriber count
+ *  - Set addon.enabled = false to globally hide an add-on
+ *  - Fill in stripePriceIds after creating Stripe Products + Prices
+ *  - Update checkout.apiEndpoint when the Rails endpoint is deployed
+ *  - Update webhooks.emailCapture with the Zapier/API endpoint for drip sequence
+ */
+
+const PRICING_CONFIG = {
+
+  // ──────────────────────────────────────────────
+  // List size tiers — drives core newsletter price
+  // ──────────────────────────────────────────────
+  listSizeTiers: [
+    {
+      id: 'starter',
+      label: 'Under 5,000 subscribers',
+      // Per-month rates (customer sees these); actual billed amount = rate × period multiplier
+      rates: { monthly: 299, quarterly: 199, annual: 169 },
+    },
+    // Add more tiers as needed, e.g.:
+    // { id: '5k-10k', label: '5,000 – 10,000 subscribers', rates: { monthly: 395, quarterly: 345, annual: 242 } },
+  ],
+
+  // ──────────────────────────────────────────────
+  // Add-ons
+  // ──────────────────────────────────────────────
+  addons: [
+    {
+      id: 'linkedin',
+      name: 'LinkedIn Add-on',
+      billingType: 'recurring', // billed at same interval as core
+      originalPricePerMonth: 99,  // shown crossed out
+      salePricePerMonth: 49,      // active price
+      saleLabel: '7-day sign-on deal',
+      description: [
+        'LinkedIn content repurposed directly from your newsletter each week',
+        'Consistent posting schedule to build your professional presence',
+        'Strategic formatting optimized for LinkedIn reach and engagement',
+      ],
+      enabled: true,
+    },
+    {
+      id: 'welcome-sequence',
+      name: 'Done-for-You Welcome Sequence',
+      billingType: 'one_time',
+      flatPrice: 249,
+      priceLabel: '$249',
+      description: [
+        'A professionally written 3-email welcome sequence for new subscribers',
+        'Sets the right expectations and builds trust from day one',
+        'Delivered within your first 30 days',
+      ],
+      enabled: true,
+    },
+    {
+      id: 'content-interviews',
+      name: 'Content Interviews',
+      billingType: 'recurring', // billed at same interval as core
+      pricePerMonth: 199,
+      description: [
+        'Monthly recorded interview to extract your expertise and voice',
+        'We turn your insights into ready-to-publish newsletter content',
+        'Keeps your newsletter authentic without extra writing effort on your end',
+      ],
+      enabled: true,
+    },
+    {
+      id: 'performance',
+      name: 'Performance Marketing Pilot',
+      billingType: 'one_time',
+      flatPrice: 3000,
+      priceLabel: 'Starting at $3,000',
+      description: [
+        'Targeted paid campaigns designed to grow your subscriber list',
+        'We handle creative, targeting, and ongoing optimization',
+        'Minimum 30-day pilot with full performance reporting',
+      ],
+      enabled: true,
+    },
+  ],
+
+  // ──────────────────────────────────────────────
+  // Stripe Payment Links
+  // Recurring links keyed by billing period + addon combo.
+  // Key format: 'core' | 'core+linkedin' | 'core+content-interviews' | 'core+linkedin+content-interviews'
+  // One-time links: fill in when Stripe payment links are created for those add-ons.
+  // ──────────────────────────────────────────────
+  paymentLinks: {
+    recurring: {
+      monthly: {
+        'core':                             'https://buy.stripe.com/dRmfZi7YT02EgsmeBGcEw1C',
+        'core+linkedin':                    'https://buy.stripe.com/7sY4gAgvpg1C2BwbpucEw1D',
+        'core+content-interviews':          'https://buy.stripe.com/4gM3cwbb53eQ0to79ecEw1E',
+        'core+linkedin+content-interviews': 'https://buy.stripe.com/14A14ocf9bLm7VQdxCcEw1F',
+      },
+      quarterly: {
+        'core':                             'https://buy.stripe.com/00w4gA3ID5mY2Bw0KQcEw1n',
+        'core+linkedin':                    'https://buy.stripe.com/14AeVebb5bLm3FAalqcEw1z',
+        'core+content-interviews':          'https://buy.stripe.com/fZu28s2Ez7v65NI79ecEw1B',
+        'core+linkedin+content-interviews': 'https://buy.stripe.com/cNieVea71dTua3Y3X2cEw1A',
+      },
+      annual: {
+        'core':                             'https://buy.stripe.com/aFaeVe7YT5mYeke9hmcEw1G',
+        'core+linkedin':                    'https://buy.stripe.com/aFafZi4MH5mY4JEalqcEw1H',
+        'core+content-interviews':          'https://buy.stripe.com/eVq5kE2EzeXy4JE65acEw1I',
+        'core+linkedin+content-interviews': 'https://buy.stripe.com/3cI6oI0wr16Ifoi8dicEw1J',
+      },
+    },
+    // One-time add-on links — fill these in once created in Stripe.
+    // Set each link's Stripe "Confirmation page" redirect to checkout.onetimeDoneUrl below.
+    oneTime: {
+      'welcome-sequence': 'PLACEHOLDER_welcome_sequence_payment_link',
+      'performance':      'PLACEHOLDER_performance_payment_link',
+    },
+  },
+
+  // ──────────────────────────────────────────────
+  // Post-payment redirect URLs
+  // Configure these as the "Confirmation page" URL in each Stripe Payment Link.
+  // ──────────────────────────────────────────────
+  checkout: {
+    successUrl:     'https://withpotions.com/pricing-calculator.html?step=3&success=true',
+    onetimeDoneUrl: 'https://withpotions.com/pricing-calculator.html?step=3&onetime_done=true&success=true',
+    cancelUrl:      'https://withpotions.com/pricing-calculator.html?step=2',
+  },
+
+  // ──────────────────────────────────────────────
+  // Webhooks — POST after email capture
+  // Swap for your Rails API endpoint when ready.
+  // ──────────────────────────────────────────────
+  webhooks: {
+    emailCapture: 'https://hooks.zapier.com/hooks/catch/PLACEHOLDER',
+  },
+};

--- a/pricing-calculator.html
+++ b/pricing-calculator.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Configure your Potions newsletter plan and add-ons. See live pricing and check out in one step."
+    />
+    
+    <meta property="og:image" content="https://withpotions.com/PotionsPreview.png" />
+    
+    <meta
+      name="keywords"
+      content="Potions pricing, newsletter pricing, B2B newsletter plan"
+    />
+    <meta name="author" content="Potions" />
+    <meta http-equiv="Permissions-Policy" content="payment=(self https://calendly.com)" />
+    <!-- Preload critical CSS -->
+    <link rel="preload" href="style.css" as="style" />
+    <link rel="stylesheet" href="style.css" />
+    <!-- Preload critical font -->
+    <link rel="preload" href="webfonts/prosa-light.woff2" as="font" type="font/woff2" crossorigin />
+    <!-- Preload hero background image -->
+    <!-- <link rel="preload" href="landing-page-banner.webp" as="image" fetchpriority="high" /> -->
+    
+        
+    <link rel="stylesheet" href="onboarding.css" />
+        
+    <link rel="stylesheet" href="css/pricing-calculator.css" />
+        
+    
+<!--     <link rel="icon" href="https://withpotions.com/airplane.svg" /> -->
+<!--     <link rel="icon" href="https://withpotions.com/airplane.ico" /> -->
+<!--     <link rel="canonical" href="https://withpotions.com/pricing-calculator.html" /> -->
+
+    <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/site.webmanifest" />
+
+    <title>
+      Build Your Potions Plan | Potions
+    </title>
+
+    <script src="lottie.min.js" defer></script>
+
+    
+
+  </head>
+  <body>
+  
+  <!-- Google Tag Manager (noscript) -->
+<!--<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W879CWPC"-->
+<!--height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>-->
+<!-- End Google Tag Manager (noscript) -->
+
+
+    
+    <!-- Dev mode banner -->
+<div id="dev-banner" class="dev-banner" style="display:none;">
+  DEV MODE — Stripe checkout is bypassed
+</div>
+
+<!-- Pricing Calculator -->
+<div class="onboarding-wrapper">
+  <div class="onboarding-container">
+
+    <!-- Progress Bar -->
+    <div class="progress-bar-container">
+      <div class="progress-bar">
+        <div class="progress-fill" id="pricing-progress-fill" style="width: 25%;"></div>
+      </div>
+      <div class="progress-text" id="pricing-progress-text">Step 1 of 4</div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Step 1: Configure your plan                 -->
+    <!-- ═══════════════════════════════════════════ -->
+    <div class="onboarding-step pricing-step" id="pricing-step-1">
+      <div class="step-content">
+
+        <h1>Build your Potions plan</h1>
+        <p class="step-helper">Select the features that fit your goals. Your price updates live.</p>
+
+        <!-- Billing period toggle -->
+        <div class="billing-toggle-section">
+          <span class="billing-toggle-label">Billing period</span>
+          <div class="billing-toggle" id="billing-toggle">
+            <button class="billing-btn" data-billing="monthly">Monthly</button>
+            <button class="billing-btn active" data-billing="quarterly">Quarterly</button>
+            <button class="billing-btn" data-billing="annual">Annual</button>
+          </div>
+        </div>
+
+        <!-- List size -->
+        <div class="list-size-section">
+          <span class="list-size-label">Subscriber list size</span>
+          <select class="list-size-select" id="list-size-select">
+            <!-- Options populated by JS from config -->
+          </select>
+        </div>
+
+        <!-- Core newsletter row (always included) -->
+        <div class="core-row">
+          <div class="core-row-info">
+            <div class="core-row-name">Potions Newsletter (included)</div>
+            <div class="core-row-sub">Weekly done-for-you newsletter, custom design, dedicated Slack, 1-on-1 calls</div>
+          </div>
+          <div class="core-row-price">
+            <span class="core-price-amount" id="core-price-amount">$199/mo</span>
+            <span class="core-price-period" id="core-price-period">billed quarterly</span>
+          </div>
+        </div>
+
+        <!-- Add-ons -->
+        <span class="addons-section-label">Add-ons (optional)</span>
+        <div class="addons-table" id="addons-table">
+          <!-- Rows populated by JS -->
+        </div>
+
+        <!-- Running total -->
+        <div class="price-summary-bar">
+          <span class="price-summary-label">Your total</span>
+          <div class="price-summary-total">
+            <span class="price-summary-recurring" id="price-summary-recurring">$199/mo</span>
+            <span class="price-summary-period" id="price-summary-period">billed quarterly</span>
+            <span class="price-summary-onetime" id="price-summary-onetime" style="display:none;"></span>
+          </div>
+        </div>
+
+        <button class="btn-next" id="btn-step1-next">Review &amp; Pay &rarr;</button>
+
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Step 2: Review & Pay                        -->
+    <!-- ═══════════════════════════════════════════ -->
+    <div class="onboarding-step pricing-step" id="pricing-step-2" style="display:none;">
+      <div class="step-content">
+
+        <h1>Review your order</h1>
+        <p class="step-helper">Confirm your selection before checking out with Stripe.</p>
+
+        <!-- Order summary (populated by JS) -->
+        <div id="order-summary"></div>
+
+        <!-- Checkout error -->
+        <div id="checkout-error" class="email-submit-error" style="display:none;"></div>
+
+        <!-- Pay button -->
+        <button class="btn-pay-now" id="btn-pay-now">
+          Pay Now &rarr;
+        </button>
+        <p id="dev-skip-note" class="dev-skip-note" style="display:none;">
+          DEV MODE: clicking "Pay Now" skips Stripe and jumps to step 3
+        </p>
+        <p class="pay-security-note">Secure checkout powered by Stripe</p>
+
+        <div class="step-navigation" style="margin-top: 1.5rem;">
+          <button class="btn-back" id="btn-step2-back">&larr; Back</button>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Step 2b: One-time add-on payment            -->
+    <!-- ═══════════════════════════════════════════ -->
+    <div class="onboarding-step pricing-step" id="pricing-step-2b" style="display:none;">
+      <div class="step-content">
+
+        <div class="payment-confirmed-banner">
+          ✓ Payment 1 confirmed — subscription is active
+        </div>
+        <h1>Payment 2 of 2</h1>
+        <p class="step-helper">Complete your one-time add-ons below. Each opens a quick Stripe checkout.</p>
+
+        <!-- One-time add-on payment buttons (populated by JS) -->
+        <div id="onetime-payment-items"></div>
+
+        <p class="pay-security-note">Secure checkout powered by Stripe</p>
+
+        <div class="step-navigation" style="margin-top: 1.5rem;">
+          <button class="btn-back" id="btn-skip-onetime">Skip for now &rarr;</button>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Step 3: Email capture (post-payment)        -->
+    <!-- ═══════════════════════════════════════════ -->
+    <div class="onboarding-step pricing-step" id="pricing-step-3" style="display:none;">
+      <div class="step-content">
+
+        <h1>One last thing</h1>
+        <p class="step-helper">What email should we use for your Potions account?</p>
+
+        <div class="email-capture-form">
+          <input
+            type="email"
+            id="email-input"
+            class="pricing-email-input"
+            placeholder="you@yourcompany.com"
+            autocomplete="email"
+          />
+          <p class="email-privacy-note">
+            This becomes your Potions login and the address where we send your
+            newsletter drafts, educational content, and account updates.
+          </p>
+          <button class="btn-finish-setup" id="btn-finish-setup" disabled>
+            Finish Setup &rarr;
+          </button>
+          <div id="email-submit-error" class="email-submit-error"></div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Step 4: Welcome!                            -->
+    <!-- ═══════════════════════════════════════════ -->
+    <div class="onboarding-step pricing-step welcome-page" id="pricing-step-4" style="display:none;">
+      <div class="step-content">
+
+        <!-- Success icon -->
+        <div class="success-icon">
+          <svg viewBox="0 0 52 52" width="80" height="80">
+            <circle cx="26" cy="26" r="25" fill="none" stroke="#5D5DED" stroke-width="2"/>
+            <path fill="none" stroke="#5D5DED" stroke-width="3" d="M14.1 27.2l7.1 7.2 16.7-16.8"/>
+          </svg>
+        </div>
+
+        <h1>You're all set!</h1>
+
+        <p class="thank-you-message">
+          Welcome to Potions. We're excited to build your newsletter with you.
+          You'll hear from us within one business day to kick things off.
+        </p>
+
+        <!-- Inbox instruction -->
+        <div class="inbox-instruction">
+          <h3>Important: find our welcome email</h3>
+          <p>
+            We just sent you a welcome email. If you don't see it in your inbox,
+            check your <strong>Promotions</strong> or <strong>Spam</strong> folder and
+            drag it to your <strong>Primary inbox</strong> — this ensures you receive
+            your newsletter drafts and updates without interruption.
+          </p>
+        </div>
+
+        <!-- What's next -->
+        <div class="next-steps">
+          <h2>What happens next?</h2>
+          <ol class="next-steps-list">
+            <li>Our team will review your account and reach out within one business day</li>
+            <li>We'll schedule your onboarding call to align on voice, audience, and goals</li>
+            <li>Your first newsletter draft lands in your inbox within 7 days of your call</li>
+          </ol>
+        </div>
+
+        <!-- Resources -->
+        <div class="resources-section">
+          <h2>See what we can do</h2>
+          <div class="resource-links">
+            <a href="https://withpotions.com/blog/stat-digital-case-study.html" target="_blank" rel="noopener" class="resource-link">
+              <span class="link-icon">&#128218;</span>
+              <span class="link-text">Read our case study</span>
+            </a>
+            <a href="https://withpotions.com/samples.html" target="_blank" rel="noopener" class="resource-link">
+              <span class="link-icon">&#10024;</span>
+              <span class="link-text">See sample newsletters</span>
+            </a>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div><!-- /.onboarding-container -->
+</div><!-- /.onboarding-wrapper -->
+
+<!-- Scripts loaded here (like the onboarding funnel) so they can reference the DOM -->
+<script src="js/pricing/config.js" defer></script>
+<script src="js/pricing/app.js" defer></script>
+
+
+
+    
+
+    
+  <!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-W879CWPC');</script>
+<!-- End Google Tag Manager -->
+
+  <script>!function () {var reb2b = window.reb2b = window.reb2b || [];if (reb2b.invoked) return;reb2b.invoked = true;reb2b.methods = ["identify", "collect"];reb2b.factory = function (method) {return function () {var args = Array.prototype.slice.call(arguments);args.unshift(method);reb2b.push(args);return reb2b;};};for (var i = 0; i < reb2b.methods.length; i++) {var key = reb2b.methods[i];reb2b[key] = reb2b.factory(key);}reb2b.load = function (key) {var script = document.createElement("script");script.type = "text/javascript";script.async = true;script.src = "https://s3-us-west-2.amazonaws.com/b2bjsstore/b/" + key + "/reb2b.js.gz";var first = document.getElementsByTagName("script")[0];first.parentNode.insertBefore(script, first);};reb2b.SNIPPET_VERSION = "1.0.1";reb2b.load("QOQRJHY0GM62");}();</script>
+
+      <!-- Meta Pixel Code -->
+<script>
+!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+
+// Capture and store fbclid for conversion tracking
+(function() {
+  var urlParams = new URLSearchParams(window.location.search);
+  var fbclid = urlParams.get('fbclid');
+
+  if (fbclid) {
+    // Store fbclid in sessionStorage for tracking across pages
+    sessionStorage.setItem('_fbclid', fbclid);
+  }
+
+  // Retrieve stored fbclid
+  var storedFbclid = sessionStorage.getItem('_fbclid');
+
+  // Helper function to get cookie value
+  function getCookie(name) {
+    var value = '; ' + document.cookie;
+    var parts = value.split('; ' + name + '=');
+    if (parts.length === 2) return parts.pop().split(';').shift();
+    return null;
+  }
+
+  // Build advanced matching object
+  var advancedMatching = {};
+
+  // Add external_id (fbclid) if available
+  if (storedFbclid) {
+    advancedMatching.external_id = storedFbclid;
+  }
+
+  // Initialize pixel with advanced matching
+  fbq('init', '1619668331969779', advancedMatching);
+})();
+
+// Track PageView with client user agent and fbp
+(function() {
+  // Helper function to get cookie value
+  function getCookie(name) {
+    var value = '; ' + document.cookie;
+    var parts = value.split('; ' + name + '=');
+    if (parts.length === 2) return parts.pop().split(';').shift();
+    return null;
+  }
+
+  var eventData = {};
+  var fbp = getCookie('_fbp');
+  var fbc = getCookie('_fbc');
+
+  if (fbp) {
+    eventData.fbp = fbp;
+  }
+  if (fbc) {
+    eventData.fbc = fbc;
+  }
+
+  fbq('track', 'PageView', eventData, {
+    client_user_agent: navigator.userAgent
+  });
+})();
+</script>
+<noscript><img height="1" width="1" style="display:none"
+src="https://www.facebook.com/tr?id=1619668331969779&ev=PageView&noscript=1"
+alt=""
+/></noscript>
+<!-- End Meta Pixel Code -->
+    
+</body>
+</html>

--- a/templates/pages/pricing-calculator.ejs
+++ b/templates/pages/pricing-calculator.ejs
@@ -1,0 +1,228 @@
+<!-- Dev mode banner -->
+<div id="dev-banner" class="dev-banner" style="display:none;">
+  DEV MODE — Stripe checkout is bypassed
+</div>
+
+<!-- Pricing Calculator -->
+<div class="onboarding-wrapper">
+  <div class="onboarding-container">
+
+    <!-- Progress Bar -->
+    <div class="progress-bar-container">
+      <div class="progress-bar">
+        <div class="progress-fill" id="pricing-progress-fill" style="width: 25%;"></div>
+      </div>
+      <div class="progress-text" id="pricing-progress-text">Step 1 of 4</div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Step 1: Configure your plan                 -->
+    <!-- ═══════════════════════════════════════════ -->
+    <div class="onboarding-step pricing-step" id="pricing-step-1">
+      <div class="step-content">
+
+        <h1>Build your Potions plan</h1>
+        <p class="step-helper">Select the features that fit your goals. Your price updates live.</p>
+
+        <!-- Billing period toggle -->
+        <div class="billing-toggle-section">
+          <span class="billing-toggle-label">Billing period</span>
+          <div class="billing-toggle" id="billing-toggle">
+            <button class="billing-btn" data-billing="monthly">Monthly</button>
+            <button class="billing-btn active" data-billing="quarterly">Quarterly</button>
+            <button class="billing-btn" data-billing="annual">Annual</button>
+          </div>
+        </div>
+
+        <!-- List size -->
+        <div class="list-size-section">
+          <span class="list-size-label">Subscriber list size</span>
+          <select class="list-size-select" id="list-size-select">
+            <!-- Options populated by JS from config -->
+          </select>
+        </div>
+
+        <!-- Core newsletter row (always included) -->
+        <div class="core-row">
+          <div class="core-row-info">
+            <div class="core-row-name">Potions Newsletter (included)</div>
+            <div class="core-row-sub">Weekly done-for-you newsletter, custom design, dedicated Slack, 1-on-1 calls</div>
+          </div>
+          <div class="core-row-price">
+            <span class="core-price-amount" id="core-price-amount">$199/mo</span>
+            <span class="core-price-period" id="core-price-period">billed quarterly</span>
+          </div>
+        </div>
+
+        <!-- Add-ons -->
+        <span class="addons-section-label">Add-ons (optional)</span>
+        <div class="addons-table" id="addons-table">
+          <!-- Rows populated by JS -->
+        </div>
+
+        <!-- Running total -->
+        <div class="price-summary-bar">
+          <span class="price-summary-label">Your total</span>
+          <div class="price-summary-total">
+            <span class="price-summary-recurring" id="price-summary-recurring">$199/mo</span>
+            <span class="price-summary-period" id="price-summary-period">billed quarterly</span>
+            <span class="price-summary-onetime" id="price-summary-onetime" style="display:none;"></span>
+          </div>
+        </div>
+
+        <button class="btn-next" id="btn-step1-next">Review &amp; Pay &rarr;</button>
+
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Step 2: Review & Pay                        -->
+    <!-- ═══════════════════════════════════════════ -->
+    <div class="onboarding-step pricing-step" id="pricing-step-2" style="display:none;">
+      <div class="step-content">
+
+        <h1>Review your order</h1>
+        <p class="step-helper">Confirm your selection before checking out with Stripe.</p>
+
+        <!-- Order summary (populated by JS) -->
+        <div id="order-summary"></div>
+
+        <!-- Checkout error -->
+        <div id="checkout-error" class="email-submit-error" style="display:none;"></div>
+
+        <!-- Pay button -->
+        <button class="btn-pay-now" id="btn-pay-now">
+          Pay Now &rarr;
+        </button>
+        <p id="dev-skip-note" class="dev-skip-note" style="display:none;">
+          DEV MODE: clicking "Pay Now" skips Stripe and jumps to step 3
+        </p>
+        <p class="pay-security-note">Secure checkout powered by Stripe</p>
+
+        <div class="step-navigation" style="margin-top: 1.5rem;">
+          <button class="btn-back" id="btn-step2-back">&larr; Back</button>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Step 2b: One-time add-on payment            -->
+    <!-- ═══════════════════════════════════════════ -->
+    <div class="onboarding-step pricing-step" id="pricing-step-2b" style="display:none;">
+      <div class="step-content">
+
+        <div class="payment-confirmed-banner">
+          ✓ Payment 1 confirmed — subscription is active
+        </div>
+        <h1>Payment 2 of 2</h1>
+        <p class="step-helper">Complete your one-time add-ons below. Each opens a quick Stripe checkout.</p>
+
+        <!-- One-time add-on payment buttons (populated by JS) -->
+        <div id="onetime-payment-items"></div>
+
+        <p class="pay-security-note">Secure checkout powered by Stripe</p>
+
+        <div class="step-navigation" style="margin-top: 1.5rem;">
+          <button class="btn-back" id="btn-skip-onetime">Skip for now &rarr;</button>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Step 3: Email capture (post-payment)        -->
+    <!-- ═══════════════════════════════════════════ -->
+    <div class="onboarding-step pricing-step" id="pricing-step-3" style="display:none;">
+      <div class="step-content">
+
+        <h1>One last thing</h1>
+        <p class="step-helper">What email should we use for your Potions account?</p>
+
+        <div class="email-capture-form">
+          <input
+            type="email"
+            id="email-input"
+            class="pricing-email-input"
+            placeholder="you@yourcompany.com"
+            autocomplete="email"
+          />
+          <p class="email-privacy-note">
+            This becomes your Potions login and the address where we send your
+            newsletter drafts, educational content, and account updates.
+          </p>
+          <button class="btn-finish-setup" id="btn-finish-setup" disabled>
+            Finish Setup &rarr;
+          </button>
+          <div id="email-submit-error" class="email-submit-error"></div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Step 4: Welcome!                            -->
+    <!-- ═══════════════════════════════════════════ -->
+    <div class="onboarding-step pricing-step welcome-page" id="pricing-step-4" style="display:none;">
+      <div class="step-content">
+
+        <!-- Success icon -->
+        <div class="success-icon">
+          <svg viewBox="0 0 52 52" width="80" height="80">
+            <circle cx="26" cy="26" r="25" fill="none" stroke="#5D5DED" stroke-width="2"/>
+            <path fill="none" stroke="#5D5DED" stroke-width="3" d="M14.1 27.2l7.1 7.2 16.7-16.8"/>
+          </svg>
+        </div>
+
+        <h1>You're all set!</h1>
+
+        <p class="thank-you-message">
+          Welcome to Potions. We're excited to build your newsletter with you.
+          You'll hear from us within one business day to kick things off.
+        </p>
+
+        <!-- Inbox instruction -->
+        <div class="inbox-instruction">
+          <h3>Important: find our welcome email</h3>
+          <p>
+            We just sent you a welcome email. If you don't see it in your inbox,
+            check your <strong>Promotions</strong> or <strong>Spam</strong> folder and
+            drag it to your <strong>Primary inbox</strong> — this ensures you receive
+            your newsletter drafts and updates without interruption.
+          </p>
+        </div>
+
+        <!-- What's next -->
+        <div class="next-steps">
+          <h2>What happens next?</h2>
+          <ol class="next-steps-list">
+            <li>Our team will review your account and reach out within one business day</li>
+            <li>We'll schedule your onboarding call to align on voice, audience, and goals</li>
+            <li>Your first newsletter draft lands in your inbox within 7 days of your call</li>
+          </ol>
+        </div>
+
+        <!-- Resources -->
+        <div class="resources-section">
+          <h2>See what we can do</h2>
+          <div class="resource-links">
+            <a href="https://withpotions.com/blog/stat-digital-case-study.html" target="_blank" rel="noopener" class="resource-link">
+              <span class="link-icon">&#128218;</span>
+              <span class="link-text">Read our case study</span>
+            </a>
+            <a href="https://withpotions.com/samples.html" target="_blank" rel="noopener" class="resource-link">
+              <span class="link-icon">&#10024;</span>
+              <span class="link-text">See sample newsletters</span>
+            </a>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div><!-- /.onboarding-container -->
+</div><!-- /.onboarding-wrapper -->
+
+<!-- Scripts loaded here (like the onboarding funnel) so they can reference the DOM -->
+<script src="<%= baseUrl %>js/pricing/config.js" defer></script>
+<script src="<%= baseUrl %>js/pricing/app.js" defer></script>


### PR DESCRIPTION
## Summary
- 4-step plan builder: configure plan → review & pay → email capture → welcome
- Billing toggle (monthly/quarterly/annual), list size selector, add-on selection
- Stripe payment links for all plan combinations
- Live price summary updates as selections change

## Test plan
- [ ] Visit `/pricing-calculator.html` and configure a plan
- [ ] Verify billing toggle, list size, and add-ons update prices correctly
- [ ] Test checkout flow through Stripe (or `?dev=true` to skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)